### PR TITLE
<#5cmtzu> Frontend - Add text (explanations) to each step

### DIFF
--- a/src/app/pages/indicator/indicator.component.html
+++ b/src/app/pages/indicator/indicator.component.html
@@ -1,3 +1,62 @@
+<nz-layout class="welcomeLayout">
+  <section class="welcomeSection">
+    <div nz-row class="welcomeMessage">
+      <h3 class=welcomeH3>
+        Welcome to Logframe Lab
+      </h3>
+      <hr>
+      <p>
+        Logframe Lab is an open source web application created to help NGOs and community-based organisations match
+        their project ideas with the most relevant metrics for tracking their success. This tool leads you step-by-step
+        through a simple process that results in a formatted, logical framework (logframe) that you can download and use
+        for reporting your progress to your funders.
+      </p>
+    </div>
+  </section>
+</nz-layout>
+<section class =stepSection>
+<div id="step1" class="stepInfo" *ngIf="current ===  0">
+  <p class="stepPara"> First, either upload a single Word document here (.doc or .docx) or start from scratch,
+    adding the relevant text. You can use your grant or project funding application file for this purpose. When you have
+    selected the document you wish to upload, or finished typing your text, click Next.
+  </p>
+</div>
+
+  <div id="step2" class="stepInfo" *ngIf="current ===  1">
+    <p>Now select the theme(s) that best apply to the subject of your project. You may select as many themes as you
+      want.
+      Then click Next.
+    </p>
+    <div>
+      <p class="stepPara">Note: If you are unsure which themes are relevant, don’t worry – you’ll be able to add more filters in Step 4.
+      </p>
+    </div>
+  </div>
+  <div id="step3" class="stepInfo" *ngIf="current ===  2">
+    <p class="stepPara">Your document is now being uploaded and scanned for appropriate keywords. The green check mark lets you know when
+      your document is done. Then click Next.
+    </p>
+  </div>
+  <div id="step4" class="stepInfo" *ngIf="current ===  3">
+    <p >Here are the suggested indicators for you, based on the keywords in your document and the themes selected.
+      Indicators are categorised as Impacts, Outcomes, or Outputs. Select the indicators you want to use to track the
+      success of your project, then click Next.</p>
+    <div>
+      <p class="stepPara" >  Note: In this step, you can select additional themes or indicators that you wish to include in your logframe.
+      </p>
+    </div>
+  </div>
+  <div id="step5" class="stepInfo" *ngIf="current ===  4">
+    <p class="stepPara">Now you can arrange your indicators to note which Outputs belong with which Outcomes, and which Outcomes are
+      assigned to which Impacts. Once you have finished grouping these indicators, click Next.
+    </p>
+  </div>
+  <div id="step6" class="stepInfo" *ngIf="current ===  5">
+    <p class="stepPara">Here the indicators have been put into a logframe that you can now download and use for tracking progress on your
+      project – and for reporting to funders.
+    </p>
+  </div>
+</section>
 <div class="content-section">
   <nz-steps [nzCurrent]="current">
     <nz-step nzTitle="SELECT"></nz-step>

--- a/src/app/pages/indicator/indicator.component.scss
+++ b/src/app/pages/indicator/indicator.component.scss
@@ -15,3 +15,75 @@
 .steps-action {
   margin-top: 24px;
 }
+.welcomeLayout{
+  background-color:  white;
+  align-items: center;
+  padding: 3rem;
+  }
+  
+  .welcomeSection{
+  text-align: left;
+  padding: 2rem 5rem;
+  }
+  .welcomeH3{
+    padding: 1.5rem 0rem 1.5rem 0rem;
+    line-height: 3.5rem;
+    font-size: 3rem;
+    font-weight: 900;
+    text-align: center;
+    font-family:montserrat, sans-serif;
+    transform: scale(1, 1.5);
+    }
+  .welcomeMessage{
+  font-size:.90rem;
+  font-weight: 500;
+  line-height: 1rem;
+  background-color: rgb(233, 233, 233);
+  padding: 25px;
+  border-radius: 15px;
+  border-top-left-radius: 15px;
+  box-shadow: .25rem .35rem .1625rem #00000029;
+  max-width: 48rem;
+  }
+  .stepSection{
+    padding: 0rem 2rem 2rem 2rem;
+  }
+  .stepInfo{
+    margin: auto;
+    
+    font-family:montserrat, sans-serif;
+    font-weight: 500;
+    line-height: 1.25rem;
+    font-size: 1.25rem;
+    background-color:#1890ff;
+    color: white;
+    padding: .5rem 1rem .5rem 1rem;
+    border-radius: 1rem;
+    box-shadow: .25rem .35rem .1625rem #00000029;
+    max-width: 30rem;
+  }
+  .stepPara{
+    margin-bottom: 0;
+  }
+  // #step1{
+  //   position: relative;
+  // }
+  // #step2{
+  //   position: relative;
+  //   right: 20%;
+  // }
+  // #step3{
+  //   position: relative;
+  //   right: 5%;
+  // }
+  // #step4{
+  //   position: relative;
+  //   left: 9.75%;
+  // }
+  // #step5{
+  //   position: relative;
+  //   left: 25%;
+  // }
+  // #step6{
+  //   position: relative;
+  // }

--- a/src/app/pages/indicator/selectdocument/selectdocument.component.html
+++ b/src/app/pages/indicator/selectdocument/selectdocument.component.html
@@ -18,4 +18,14 @@
     </p>
     <p>{{ fileName }}</p>
   </div>
+  <nz-content>
+    <div class="disclaimer">
+      <p class="disclaimerText">
+        <b>Disclaimer:</b> Uploading data here is safe. You can trust us with your info, because we never save it
+        anywhere. The algorithm uses your text to scan for keywords and retains access to it only so you can complete the procedure.
+        Your data is discarded as soon as you click ‘done’ in the 6th step, or if you refresh the window before you’re done.
+        We cannot access your information at any point.
+      </p>
+    </div>
+  </nz-content>
 </nz-upload>

--- a/src/app/pages/indicator/selectdocument/selectdocument.component.scss
+++ b/src/app/pages/indicator/selectdocument/selectdocument.component.scss
@@ -1,0 +1,15 @@
+.disclaimer{
+    width: 60%;
+    position: absolute;
+    right: 0rem;
+    bottom: 0rem;
+    border: 2px solid #1890ff;
+    max-height: 9rem;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+.disclaimerText{
+    text-align: left;
+    padding: .2rem;
+    
+}


### PR DESCRIPTION
Added required text to the website along with some light CSS edits. 
-Indicator.component.scss has some CSS blocked out, I tried to sync the information block explaining each step with the step number.  
-nzDescription was difficult to use, as I could not change the default margin. (too slim)
-I can add a component for each description if needed to clean up the indicator.html file a bit!
-Disclaimer will overflow with a scroll bar

